### PR TITLE
ci: converge with private sibling + clear deuce clippy debt

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -4,7 +4,6 @@ on:
   push:
     branches: [main]
   pull_request:
-    branches: [main]
   workflow_dispatch:
 
 # Cancel superseded runs on the same ref (e.g. PR push during in-flight build).
@@ -25,7 +24,7 @@ env:
 
 jobs:
   format:
-    name: Format
+    name: Rust Format
     runs-on: ubuntu-latest
     timeout-minutes: 5
     steps:
@@ -66,7 +65,7 @@ jobs:
   compile:
     name: Compile (${{ matrix.features }})
     runs-on: ubuntu-latest
-    timeout-minutes: 15
+    timeout-minutes: 25
     strategy:
       fail-fast: false
       matrix:

--- a/crates/deuce/src/hand_iter.rs
+++ b/crates/deuce/src/hand_iter.rs
@@ -140,31 +140,31 @@ mod tests {
     #[test]
     fn choose_3() {
         let mut iter = HandIterator::from((3, Hand::empty()));
-        assert!(iter.next() == Some(Hand::from(0b00111)));
-        assert!(iter.next() == Some(Hand::from(0b01011)));
-        assert!(iter.next() == Some(Hand::from(0b01101)));
-        assert!(iter.next() == Some(Hand::from(0b01110)));
-        assert!(iter.next() == Some(Hand::from(0b10011)));
-        assert!(iter.next() == Some(Hand::from(0b10101)));
-        assert!(iter.next() == Some(Hand::from(0b10110)));
-        assert!(iter.next() == Some(Hand::from(0b11001)));
-        assert!(iter.next() == Some(Hand::from(0b11010)));
-        assert!(iter.next() == Some(Hand::from(0b11100)));
+        assert_eq!(iter.next(), Some(Hand::from(0b00111)));
+        assert_eq!(iter.next(), Some(Hand::from(0b01011)));
+        assert_eq!(iter.next(), Some(Hand::from(0b01101)));
+        assert_eq!(iter.next(), Some(Hand::from(0b01110)));
+        assert_eq!(iter.next(), Some(Hand::from(0b10011)));
+        assert_eq!(iter.next(), Some(Hand::from(0b10101)));
+        assert_eq!(iter.next(), Some(Hand::from(0b10110)));
+        assert_eq!(iter.next(), Some(Hand::from(0b11001)));
+        assert_eq!(iter.next(), Some(Hand::from(0b11010)));
+        assert_eq!(iter.next(), Some(Hand::from(0b11100)));
     }
     #[test]
     fn choose_3_from_5() {
         let mask = Hand::from(0b_________________1111_00_1).complement();
         let mut iter = HandIterator::from((3, mask));
-        assert!(iter.next() == Some(Hand::from(0b0011_00_1)));
-        assert!(iter.next() == Some(Hand::from(0b0101_00_1)));
-        assert!(iter.next() == Some(Hand::from(0b0110_00_1)));
-        assert!(iter.next() == Some(Hand::from(0b0111_00_0)));
-        assert!(iter.next() == Some(Hand::from(0b1001_00_1)));
-        assert!(iter.next() == Some(Hand::from(0b1010_00_1)));
-        assert!(iter.next() == Some(Hand::from(0b1011_00_0)));
-        assert!(iter.next() == Some(Hand::from(0b1100_00_1)));
-        assert!(iter.next() == Some(Hand::from(0b1101_00_0)));
-        assert!(iter.next() == Some(Hand::from(0b1110_00_0)));
+        assert_eq!(iter.next(), Some(Hand::from(0b0011_00_1)));
+        assert_eq!(iter.next(), Some(Hand::from(0b0101_00_1)));
+        assert_eq!(iter.next(), Some(Hand::from(0b0110_00_1)));
+        assert_eq!(iter.next(), Some(Hand::from(0b0111_00_0)));
+        assert_eq!(iter.next(), Some(Hand::from(0b1001_00_1)));
+        assert_eq!(iter.next(), Some(Hand::from(0b1010_00_1)));
+        assert_eq!(iter.next(), Some(Hand::from(0b1011_00_0)));
+        assert_eq!(iter.next(), Some(Hand::from(0b1100_00_1)));
+        assert_eq!(iter.next(), Some(Hand::from(0b1101_00_0)));
+        assert_eq!(iter.next(), Some(Hand::from(0b1110_00_0)));
         assert!(iter.next().is_none());
     }
 }

--- a/crates/deuce/src/isomorphism.rs
+++ b/crates/deuce/src/isomorphism.rs
@@ -114,7 +114,7 @@ mod tests {
             Hand::try_from("2s Ks").unwrap(),
             Hand::try_from("2h 5c 8d Tc Td").unwrap(),
         )));
-        assert!(a == b);
+        assert_eq!(a, b);
     }
 
     #[test]

--- a/crates/deuce/src/permutation.rs
+++ b/crates/deuce/src/permutation.rs
@@ -222,7 +222,7 @@ mod tests {
         let permutation = Permutation([Suit::C, Suit::H, Suit::D, Suit::S]);
         let original = Hand::try_from("2c 3d 4h 5s").unwrap();
         let permuted = Hand::try_from("2c 3h 4d 5s").unwrap();
-        assert!(permutation.image(&original) == permuted);
+        assert_eq!(permutation.image(&original), permuted);
     }
 
     #[test]
@@ -245,7 +245,7 @@ mod tests {
             for suit in Suit::all() {
                 let mapped = perm.map(&suit);
                 let recovered = perm.inverse().map(&mapped);
-                assert!(recovered == suit, "p(s)=t implies p^-1(t)=s");
+                assert_eq!(recovered, suit, "p(s)=t implies p^-1(t)=s");
             }
         }
     }
@@ -253,7 +253,7 @@ mod tests {
     #[test]
     fn inverse_involution() {
         for perm in Permutation::exhaust() {
-            assert!(perm.inverse().inverse() == perm, "(p^-1)^-1 = p");
+            assert_eq!(perm.inverse().inverse(), perm, "(p^-1)^-1 = p");
         }
     }
 }


### PR DESCRIPTION
Brings the public CI workflow to parity with the private sibling's shared jobs, and clears the same `deuce` clippy debt.

**CI parity** — the only remaining differences are legitimately private (Leptos format job, `--features client` compile, docs `--exclude client`):
- `pull_request`: run on **all** PRs, not just those targeting `main` (stricter).
- format job renamed `Format` → `Rust Format`.
- compile `timeout-minutes` `15` → `25`.

**deuce** — `assert!(a == b)` → `assert_eq!` (24 sites), clearing `manual_assert_eq` under stable 1.97.

⚠️ **Branch-protection note:** if `main` has a required status check named **`Format`**, update it to **`Rust Format`** or the rename will block merges.

- `cargo clippy --workspace --all-features --all-targets -- -D warnings` ✅
- `cargo test -p deuce` ✅ · `cargo fmt --check` ✅

🤖 Generated with [Claude Code](https://claude.com/claude-code)