### PR TITLE
fix: abort stale bridge task on room reconnect instead of overwriting its handle

### DIFF
--- a/crates/portal/src/hosting/casino.rs
+++ b/crates/portal/src/hosting/casino.rs
@@ -144,11 +144,24 @@ impl Casino {
             }
             tracing::debug!(bridge = %id, "disconnected");
         });
-        self.rooms
+        // A second `bridge()` call for the same room (client reconnect: page
+        // reload, sleep/wake, network blip, LB idle timeout) must replace,
+        // not merely overwrite, the stored task handle. `rx` is shared via
+        // `Arc<Mutex<..>>`, so if the previous bridge task is left running it
+        // keeps competing with this one for messages on every reconnect,
+        // non-deterministically splitting live-game broadcasts between a
+        // stale session and the new one, and the stale task/session is never
+        // cleaned up by `close()` because its AbortHandle was already
+        // discarded here.
+        if let Some(old) = self
+            .rooms
             .write()
             .await
             .get_mut(&id)
-            .map(|h| h.bridge = Some(task.abort_handle()));
+            .and_then(|h| h.bridge.replace(task.abort_handle()))
+        {
+            old.abort();
+        }
         Ok(())
     }
 }


### PR DESCRIPTION
## What
`Casino::bridge()` stored each new WebSocket task's `AbortHandle` into
`RoomHandle.bridge` by plain assignment instead of swap-and-abort.

## Why it matters
`enter()` calls `Casino::bridge()` on every WebSocket upgrade to a room's
URL, including reconnects (page reload, sleep/wake, network blip, LB idle
timeout — not an edge case). Since the room→client channel is a shared
`Arc<Mutex<UnboundedReceiver<String>>>`, leaving the previous bridge task
running means it keeps competing with the new one for every room
broadcast, so a reconnecting client can silently miss live-game events.
The stale task is also never cleaned up by `close()`, since by the time
it runs, the stored `AbortHandle` already points at the *new* task.

## Fix
Swap-and-abort: recover the previous `AbortHandle` via `Option::replace`
and abort it before storing the new one.

## Testing
`cargo check -p portal` and `cargo clippy -p portal --all-targets -- -D
warnings` both pass clean. I verified the underlying race (message split
+ task outliving `close()`) with an isolated repro of the exact
mechanism (same `Rx` type, same overwrite pattern) before touching the
real code — happy to share it if useful, or add it as a proper
integration test in `crates/portal` if that's preferred over a
standalone repro.
